### PR TITLE
fix: Correct mismatch between Luxon Info weekdays and 0 == Sunday

### DIFF
--- a/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.ts
+++ b/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.ts
@@ -110,7 +110,10 @@ export class LuxonDateAdapter extends DateAdapter<DateTime> {
   }
 
   getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
-    return Info.weekdays(style, { locale: this.locale });
+    // rotate weekday names to match 0 == Sunday (Luxon Info lists Monday at index 0)
+    // see https://moment.github.io/luxon/docs/class/src/info.js~Info.html#static-method-weekdays
+    const _weekdays = Info.weekdays(style, { locale: this.locale });
+    return _weekdays.slice(6).concat(_weekdays.slice(0,6));
   }
 
   getYearName(date: DateTime): string {


### PR DESCRIPTION
It is necessary to rotate weekday names to match 0 == Sunday used
everywhere else in Luxon. The Luxon Info structure lists Monday
at index 0.