### PR TITLE
feat: Add support for multiple 'dateInput' parse format strings

### DIFF
--- a/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.spec.ts
+++ b/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.spec.ts
@@ -376,6 +376,16 @@ describe('LuxonDateAdapter', () => {
     );
   });
 
+  it('should parse string according to first matching format', () => {
+    expect(
+      adapter.parse('1/2/2017', ['L/d/yyyy', 'yyyy/d/L'])!.toISO()
+    ).toEqual(DateTime.local(2017, JAN, 2).toISO());
+
+    expect(adapter.parse('1/2/2017', ['yyyy/d/L', 'L/d/yyyy'])!.toISO()).toEqual(
+      DateTime.local(2017, JAN, 2).toISO()
+    );
+  });
+
   it('should parse number', () => {
     let timestamp = new Date().getTime();
     expect(adapter.parse(timestamp, 'LL/dd/yyyy')!.toISO()).toEqual(

--- a/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.ts
+++ b/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.ts
@@ -169,10 +169,25 @@ export class LuxonDateAdapter extends DateAdapter<DateTime> {
         return iso8601Date;
       }
 
-      const fromFormat = DateTime.fromFormat(value, parseFormat, options);
+      if(Array.isArray(parseFormat)) {
 
-      if (this.isValid(fromFormat)) {
-        return fromFormat;
+        for(let i=0; i<parseFormat.length; i++) {
+
+          const fromFormat = DateTime.fromFormat(value, parseFormat[i], options);
+
+          if (this.isValid(fromFormat)) {
+            return fromFormat;
+          }
+
+        }
+
+      } else {
+
+        const fromFormat = DateTime.fromFormat(value, parseFormat, options);
+
+        if (this.isValid(fromFormat)) {
+          return fromFormat;
+        }
       }
 
       return this.invalid();

--- a/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.ts
+++ b/projects/ngx-material-luxon/src/lib/adapter/luxon-date-adapter.ts
@@ -159,7 +159,7 @@ export class LuxonDateAdapter extends DateAdapter<DateTime> {
     );
   }
 
-  parse(value: any, parseFormat: string): DateTime | null {
+  parse(value: any, parseFormat: string | string[]): DateTime | null {
     const options: DateTimeOptions = this._getOptions();
 
     if (typeof value == 'string' && value.length > 0) {
@@ -169,21 +169,9 @@ export class LuxonDateAdapter extends DateAdapter<DateTime> {
         return iso8601Date;
       }
 
-      if(Array.isArray(parseFormat)) {
-
-        for(let i=0; i<parseFormat.length; i++) {
-
-          const fromFormat = DateTime.fromFormat(value, parseFormat[i], options);
-
-          if (this.isValid(fromFormat)) {
-            return fromFormat;
-          }
-
-        }
-
-      } else {
-
-        const fromFormat = DateTime.fromFormat(value, parseFormat, options);
+      const parseFormats = Array.isArray(parseFormat) ? parseFormat : [parseFormat];
+      for (const format of parseFormats) {
+        const fromFormat = DateTime.fromFormat(value, format, options);
 
         if (this.isValid(fromFormat)) {
           return fromFormat;


### PR DESCRIPTION
The MomentDateModule supports an array of date format strings; the change adds the same to the `MatLuxonDateModule`.

See https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings